### PR TITLE
Proper validation of URLs to avoid matching a site like "hackexample.com"

### DIFF
--- a/app/src/main/java/com/example/app/MyWebViewClient.java
+++ b/app/src/main/java/com/example/app/MyWebViewClient.java
@@ -15,7 +15,7 @@ class MyWebViewClient extends WebViewClient {
         hostname = "example.com";
 
         Uri uri = Uri.parse(url);
-        if (url.startsWith("file:") || uri.getHost() != null && uri.getHost().endsWith(hostname)) {
+        if (url.startsWith("file:") || uri.getHost() != null && uri.getHost().endsWith("."+hostname)) {
             return false;
         }
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));


### PR DESCRIPTION
Good afternoon @vaibhavhariaramani,

I noticed an issue with the URL validation code of your repository, which has a flaw that doesn't validate the full domain. With the flaw, any website ending with "example.com" can pass the validation including "myexample.com" and "hackexample.com", etc. while I believe the intention is to match the "example.com" domain only, e.g. "www.example.com" and "corp.example.com".

Would you please investigate and merge my pull request if you agree?

Thanks @vaibhavhariaramani in advance for looking into this pull request.

@luchua-bc
